### PR TITLE
fix get-vendor-products

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,11 @@
 			<version>2.10.0.pr2</version>
 		</dependency>
 		<dependency>
+			<groupId>com.fasterxml.jackson.module</groupId>
+			<artifactId>jackson-module-kotlin</artifactId>
+			<version>2.10.0.pr2</version>
+		</dependency>
+		<dependency>
 			<groupId>javax.cache</groupId>
 			<artifactId>cache-api</artifactId>
 			<version>1.1.1</version>

--- a/src/main/java/ru/gdim/simple_java_rest_api/service/resource_version/ResourceVersion.java
+++ b/src/main/java/ru/gdim/simple_java_rest_api/service/resource_version/ResourceVersion.java
@@ -1,36 +1,5 @@
 package ru.gdim.simple_java_rest_api.service.resource_version;
 
-import com.hazelcast.nio.ObjectDataInput;
-import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.DataSerializable;
-import lombok.*;
-import org.jetbrains.annotations.NotNull;
+public interface ResourceVersion {
 
-import java.io.IOException;
-import java.net.URL;
-
-@AllArgsConstructor
-@NoArgsConstructor
-@Getter
-@Setter
-@EqualsAndHashCode
-@ToString
-public final class ResourceVersion implements DataSerializable {
-    private URL url;
-    private String eTag;
-    private String lastModified;
-
-    @Override
-    public void writeData(@NotNull ObjectDataOutput objectDataOutput) throws IOException {
-        objectDataOutput.writeObject(url);
-        objectDataOutput.writeUTF(eTag);
-        objectDataOutput.writeUTF(lastModified);
-    }
-
-    @Override
-    public void readData(@NotNull ObjectDataInput objectDataInput) throws IOException {
-        url = objectDataInput.readObject(URL.class);
-        eTag = objectDataInput.readUTF();
-        lastModified = objectDataInput.readUTF();
-    }
 }

--- a/src/main/java/ru/gdim/simple_java_rest_api/service/resource_version/ResourceVersionImpl.java
+++ b/src/main/java/ru/gdim/simple_java_rest_api/service/resource_version/ResourceVersionImpl.java
@@ -1,0 +1,36 @@
+package ru.gdim.simple_java_rest_api.service.resource_version;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.DataSerializable;
+import lombok.*;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+import java.net.URL;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@EqualsAndHashCode
+@ToString
+public final class ResourceVersionImpl implements ResourceVersion, DataSerializable {
+    private URL url;
+    private String eTag;
+    private String lastModified;
+
+    @Override
+    public void writeData(@NotNull ObjectDataOutput objectDataOutput) throws IOException {
+        objectDataOutput.writeObject(url);
+        objectDataOutput.writeUTF(eTag);
+        objectDataOutput.writeUTF(lastModified);
+    }
+
+    @Override
+    public void readData(@NotNull ObjectDataInput objectDataInput) throws IOException {
+        url = objectDataInput.readObject(URL.class);
+        eTag = objectDataInput.readUTF();
+        lastModified = objectDataInput.readUTF();
+    }
+}

--- a/src/main/java/ru/gdim/simple_java_rest_api/service/resource_version/ResourceVersionService.java
+++ b/src/main/java/ru/gdim/simple_java_rest_api/service/resource_version/ResourceVersionService.java
@@ -56,6 +56,6 @@ public final class ResourceVersionService {
             return null;
         }
 
-        return new ResourceVersion(url, eTag, lastModified);
+        return new ResourceVersionImpl(url, eTag, lastModified);
     }
 }


### PR DESCRIPTION
Add ResourceVersion interface

Fix build warning:

> WARN 20364 --- [kground-preinit] o.s.h.c.j.Jackson2ObjectMapperBuilder    : For Jackson Kotlin classes support please add "com.fasterxml.jackson.module:jackson-module-kotlin" to the classpath